### PR TITLE
use Tensor.item() to avoid uint8 overflow

### DIFF
--- a/experiments/recognition/main.py
+++ b/experiments/recognition/main.py
@@ -92,13 +92,13 @@ def main():
             loss.backward()
             optimizer.step()
 
-            train_loss += loss.data[0]
+            train_loss += loss.item()
             pred = output.data.max(1)[1] 
             correct += pred.eq(target.data).cpu().sum()
             total += target.size(0)
-            err = 100-100.*correct/total
+            err = 100-100.*correct.item()/total
             tbar.set_description('\rLoss: %.3f | Err: %.3f%% (%d/%d)' % \
-                (train_loss/(batch_idx+1), err, total-correct, total))
+                (train_loss/(batch_idx+1), err, total-correct.item(), total))
 
         errlist_train += [err]
 


### PR DESCRIPTION
Hi,

I was unable to train a model on MINC:

```sh
experiments/recognition$ CUDA_VISIBLE_DEVICES=1 python main.py --model deepten --nclass 23 --model deepten --batch-size 64 --lr 0.01 --epochs 60 --dataset minc
```

I got several errors like this:

```py
  File "main.py", line 99, in train
    err = 100-100.*correct/total
RuntimeError: value cannot be converted to type uint8_t without overflow: 256
```

I discovered that `correct` is a `ByteTensor` which is the source of the `uint8` conversion, so in this PR I fixed the errors by using `Tensor.item()` to convert the `correct` count to a Python integer before doing math with it.

I made the same change with `loss.data[0]` -> `loss.item()` because I got a warning saying to do that.

I'm not sure if this is the correct fix, but at least the model is training on my machine now!