### PR TITLE
fixed compatibility issues with the new pytorch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ docs/src/
 docs/html/
 encoding/_ext/
 encoding.egg-info/
+encoding/lib/gpu/.*
+encoding/lib/gpu/*.o
+encoding/lib/gpu/*.so
+

--- a/encoding/lib/gpu/encoding_kernel.cu
+++ b/encoding/lib/gpu/encoding_kernel.cu
@@ -1,5 +1,5 @@
 #include <vector>
-#include <torch/tensor.h>
+//#include <torch/tensor.h>
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
@@ -87,7 +87,7 @@ __global__ void Aggregate_Forward_kernel (
 template<typename DType, typename Acctype>
 __global__ void Aggregate_Backward_kernel (
     DeviceTensor<DType, 3> GA,
-    DeviceTensor<DType, 3> GE,
+    DeviceTensor<DType, 1> GE,
     DeviceTensor<DType, 3> A,
     DeviceTensor<DType, 3> X,
     DeviceTensor<DType, 2> C) {
@@ -166,7 +166,7 @@ at::Tensor Aggregate_Forward_CUDA(
     const at::Tensor X_,
     const at::Tensor C_) {
   /* Device tensors */
-  auto E_ = torch::zeros({A_.size(0), C_.size(0), C_.size(1)}, A_.options());
+  auto E_ = at::zeros({A_.size(0), C_.size(0), C_.size(1)}, A_.options());
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   // B, K, D
   dim3 blocks(C_.size(1), C_.size(0), X_.size(0));
@@ -215,7 +215,7 @@ at::Tensor ScaledL2_Forward_CUDA(
     const at::Tensor X_,
     const at::Tensor C_,
     const at::Tensor S_) {
-  auto SL_ = torch::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
+  auto SL_ = at::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   dim3 blocks(C_.size(0), X_.size(1), X_.size(0));
   dim3 threads(getNumThreads(C_.size(1)));

--- a/encoding/lib/gpu/encoding_kernel.cu
+++ b/encoding/lib/gpu/encoding_kernel.cu
@@ -87,7 +87,7 @@ __global__ void Aggregate_Forward_kernel (
 template<typename DType, typename Acctype>
 __global__ void Aggregate_Backward_kernel (
     DeviceTensor<DType, 3> GA,
-    DeviceTensor<DType, 1> GE,
+    DeviceTensor<DType, 3> GE,
     DeviceTensor<DType, 3> A,
     DeviceTensor<DType, 3> X,
     DeviceTensor<DType, 2> C) {

--- a/encoding/lib/gpu/encodingv2_kernel.cu
+++ b/encoding/lib/gpu/encodingv2_kernel.cu
@@ -1,5 +1,5 @@
 #include <vector>
-#include <torch/tensor.h>
+//#include <torch/tensor.h>
 #include <ATen/ATen.h>
 #include <ATen/Functions.h>
 #include <ATen/cuda/CUDAContext.h>
@@ -240,7 +240,7 @@ at::Tensor Encoding_Dist_Inference_Forward_CUDA(
     const at::Tensor STD_) {
     // const at::Tensor S_,
   // X \in R^{B, N, D}, C \in R^{K, D}, S \in R^K
-  auto KD_ = torch::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
+  auto KD_ = at::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
   // E(x), E(x^2)
   int N = X_.size(0) * X_.size(1);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -302,7 +302,7 @@ std::vector<at::Tensor> Encoding_Dist_Forward_CUDA(
     double eps) {
     // const at::Tensor S_,
   // X \in R^{B, N, D}, C \in R^{K, D}, S \in R^K
-  auto KD_ = torch::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
+  auto KD_ = at::zeros({X_.size(0), X_.size(1), C_.size(0)}, X_.options());
   // E(x), E(x^2)
   int N = X_.size(0) * X_.size(1);
   auto SVar_ = (X_.pow(2).sum(0).sum(0).view({1, X_.size(2)}) -
@@ -374,7 +374,7 @@ at::Tensor AggregateV2_Forward_CUDA(
     const at::Tensor C_,
     const at::Tensor STD_) {
   /* Device tensors */
-  auto E_ = torch::zeros({A_.size(0), C_.size(0), C_.size(1)}, A_.options());
+  auto E_ = at::zeros({A_.size(0), C_.size(0), C_.size(1)}, A_.options());
   // auto IS_ = 1.0f / (S_ + eps).sqrt();
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   // B, K, D

--- a/encoding/lib/gpu/nms_kernel.cu
+++ b/encoding/lib/gpu/nms_kernel.cu
@@ -1,4 +1,4 @@
-#include <torch/tensor.h>
+//#include <torch/tensor.h>
 #include <ATen/ATen.h>
 #include "ATen/NativeFunctions.h"
 #include <ATen/cuda/CUDAContext.h>
@@ -77,7 +77,7 @@ std::vector<at::Tensor> Non_Max_Suppression_CUDA(
   auto num_boxes = input.size(1);
   auto batch_size = input.size(0);
   //auto mask = input.type().toScalarType(at::kByte).tensor({batch_size, num_boxes});
-  auto mask = torch::zeros({batch_size, num_boxes}, input.type().toScalarType(at::kByte));
+  auto mask = at::zeros({batch_size, num_boxes}, input.type().toScalarType(at::kByte));
   mask.fill_(1);
   
   //need the indices of the boxes sorted by score.

--- a/encoding/lib/gpu/roi_align_kernel.cu
+++ b/encoding/lib/gpu/roi_align_kernel.cu
@@ -1,4 +1,4 @@
-#include <torch/tensor.h>
+//#include <torch/tensor.h>
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
@@ -368,7 +368,7 @@ at::Tensor ROIAlign_Forward_CUDA(
   auto width = input.size(3);
 
   // Output Tensor is (num_rois, C, pooled_height, pooled_width)
-  auto output = torch::zeros({proposals, channels, pooled_height, pooled_width}, input.options());
+  auto output = at::zeros({proposals, channels, pooled_height, pooled_width}, input.options());
 
   auto count = output.numel();
   
@@ -415,7 +415,7 @@ at::Tensor ROIAlign_Backward_CUDA(
 
   // Output Tensor is (num_rois, C, pooled_height, pooled_width)
   // gradient wrt input features
-  auto grad_in = torch::zeros({b_size, channels, height, width}, rois.options());
+  auto grad_in = at::zeros({b_size, channels, height, width}, rois.options());
   auto num_rois = rois.size(0);
   auto count = grad_output.numel();
 

--- a/encoding/lib/gpu/syncbn_kernel.cu
+++ b/encoding/lib/gpu/syncbn_kernel.cu
@@ -1,5 +1,5 @@
 #include <vector>
-#include <torch/tensor.h>
+//#include <torch/tensor.h>
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
@@ -245,8 +245,8 @@ std::vector<at::Tensor> BatchNorm_Backward_CUDA(
 std::vector<at::Tensor> Sum_Square_Forward_CUDA(
     const at::Tensor input_) {
   /* outputs */
-  at::Tensor sum_ = torch::zeros({input_.size(1)}, input_.options());
-  at::Tensor square_ = torch::zeros({input_.size(1)}, input_.options());
+  at::Tensor sum_ = at::zeros({input_.size(1)}, input_.options());
+  at::Tensor square_ = at::zeros({input_.size(1)}, input_.options());
   /* cuda utils*/
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   dim3 blocks(input_.size(1));


### PR DESCRIPTION
I changed the lib/gpu and lib/cpu to make it compatible with the new pytorch as the header file tensor.h seems to not exist anymore. I replaced all the occurences of torch::zeros in the code by at::zeros