### PR TITLE
Missing double quotes on string

### DIFF
--- a/encoding/datasets/__init__.py
+++ b/encoding/datasets/__init__.py
@@ -28,7 +28,7 @@ acronyms = {
     'coco': 'coco',
     'pascal_voc': 'voc',
     'pascal_aug': 'voc',
-    'pcontext': pcontext,
+    'pcontext': 'pcontext',
     'ade20k': 'ade',
     'citys': 'citys',
     'minc': 'minc',


### PR DESCRIPTION
acronyms 'pcontext' value missing quotations marks