### PR TITLE
Fixed out-of-date dataset name

### DIFF
--- a/docs/source/model_zoo/segmentation.rst
+++ b/docs/source/model_zoo/segmentation.rst
@@ -245,7 +245,7 @@ Quick Demo
     predict = torch.max(output, 1)[1].cpu().numpy() + 1
 
     # Get color pallete for visualization
-    mask = encoding.utils.get_mask_pallete(predict, 'pcontext')
+    mask = encoding.utils.get_mask_pallete(predict, 'pascal_voc')
     mask.save('output.png')
 
 


### PR DESCRIPTION
It seems that `pcontext` is an out-of-date name. It should be `pascal_voc`. Otherwise, the user only gets an image without color like the following.
![image](https://user-images.githubusercontent.com/39628662/86460812-9f451600-bd5b-11ea-9f89-559c670e73e6.png)
